### PR TITLE
Adds gitattributes to fix EOF issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bundle text eol=lf


### PR DESCRIPTION
This should stop github from altering the line endings of the FMOD files for Mac builds